### PR TITLE
fix fish slice bug

### DIFF
--- a/xbin.fish
+++ b/xbin.fish
@@ -1,6 +1,6 @@
 function xbin
     set command $argv[1]
-    set args $argv[2..]
+    set args $argv[2..-1]
     if test -t 0
         curl -sS -X POST "https://xbin.io/$command" -H "X-Args: $args"
     else


### PR DESCRIPTION
ref to:
* https://github.com/fish-shell/fish-shell/issues/358

Currently:
```console
❯ cat .config/fish/functions/xbin.fish                                                                           (base)
function xbin
    set command $argv[1]
    set args $argv[2..]
    if test -t 0
        curl -sS -X POST "https://xbin.io/$command" -H "X-Args: $args"
    else
        curl -sS --data-binary @- "https://xbin.io/$command" -H "X-Args: $args"
    end
end
❯ xbin date                                                                                                      (base)
~/.config/fish/functions/xbin.fish (line 3): Invalid index value
    set args $argv[2..]
                      ^
in function 'xbin' with arguments 'date'
Tue May  3 16:00:22 UTC 2022
```