### PR TITLE
Fix error fetching from Cheatsheets and Man Pages

### DIFF
--- a/xbin.sh
+++ b/xbin.sh
@@ -1,7 +1,7 @@
 function xbin() {
   command="$1"
   shift
-  args="$@"
+  args=( "$@" )
   if [ -t 0 ]; then
     curl -sS -X POST "https://xbin.io/${command}" -H "X-Args: ${args}"
   else

--- a/xbin.sh
+++ b/xbin.sh
@@ -1,6 +1,7 @@
 function xbin() {
   command="$1"
-  args="${*:2}"
+  shift
+  args="$@"
   if [ -t 0 ]; then
     curl -sS -X POST "https://xbin.io/${command}" -H "X-Args: ${args}"
   else

--- a/xbin.zsh
+++ b/xbin.zsh
@@ -1,6 +1,7 @@
 % function xbin() {
   command="$1"
-  args="${*:2}"
+  shift
+  args="$@"
   if [ -t 0 ]; then
     curl -sS -X POST "https://xbin.io/${command}" -H "X-Args: ${args}"
   else

--- a/xbin.zsh
+++ b/xbin.zsh
@@ -1,7 +1,7 @@
 % function xbin() {
   command="$1"
   shift
-  args="$@"
+  args=( "$@" )
   if [ -t 0 ]; then
     curl -sS -X POST "https://xbin.io/${command}" -H "X-Args: ${args}"
   else


### PR DESCRIPTION
I'm using MacOs Monterey and I have put:


https://github.com/xbin-io/xbin/blob/main/xbin.zsh in side my ~/.zshrc

when I use `jq` by xbin, it's behaviour is right


```
13:31 ➜  ~ cat a
{
"v":"b"

}
13:31 ➜  ~ cat a | xbin jq '.v'
"b"
```

but when I try to use command like tldr

it will show the error:
```
13:33 ➜  ~ xbin tldr

Error fetching from tldr: <urlopen error [Errno -3] Try again>
```

so I have changed the xbin function and fixed it

